### PR TITLE
json_parser: support both naive and aware datetime, date and time types

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,6 +12,7 @@ Those requirements are currently:
 	itty==0.6.4
 	redis==1.34.1 
 	pystache==0.2.0
+	python-dateutil==1.5
 	
 If you'd rather install from the git repository, that's easy too::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ itty==0.6.2
 redis>=1.34.1
 pystache==0.1.0
 setproctitle>=1.0
+python-dateutil==1.5 (2.0 is for python 3.x)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'itty>=0.6.2',
         'redis>=1.34.1',
         'pystache>=0.1.0',
-        'setproctitle>=1.0'
+        'setproctitle>=1.0',
+        'python-dateutil==1.5'
     ],
     classifiers = [
             'Development Status :: 4 - Beta',

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,24 +1,44 @@
 from datetime import datetime
+from dateutil.tz import tzutc
 from tests import PyResTests
 import pyres.json_parser as json
 
 class JSONTests(PyResTests):
-    def test_encode_decode_date(self):
-        dt = datetime(1972, 1, 22);
-        encoded = json.dumps({'dt': dt})
-        decoded = json.loads(encoded)
-        assert decoded['dt'] == dt
+    def test(self):
+        naive_now = datetime.now()
+        aware_now = datetime.now(tzutc())
+        for now in [naive_now, aware_now]:
+            for obj in [now, now.date(), now.timetz(), now.time()]:
+                encoded = json.dumps(obj)
+                decoded = json.loads(encoded)
+                assert obj == decoded
 
-    def test_dates_in_lists(self):
-        dates = [datetime.now() for i in range(50)]
-        decoded = json.loads(json.dumps(dates))
-        for value in dates:
-            assert isinstance(value, datetime)
+    def test_in_list(self):
+        naive_now = datetime.now()
+        aware_now = datetime.now(tzutc())
+        for now in [naive_now, aware_now]:
+            for obj in [now, now.date(), now.timetz(), now.time()]:
+                to_encode = [1, obj]
+                encoded = json.dumps(to_encode)
+                decoded = json.loads(encoded)
+                assert to_encode == decoded
 
-    def test_dates_in_dict(self):
-        dates = dict((i, datetime.now()) for i in range(50))
-        decoded = json.loads(json.dumps(dates))
-        for i, value in dates.items():
-            assert isinstance(i, int)
-            assert isinstance(value, datetime)
+    def test_in_dict(self):
+        naive_now = datetime.now()
+        aware_now = datetime.now(tzutc())
+        for now in [naive_now, aware_now]:
+            for obj in [now, now.date(), now.timetz(), now.time()]:
+                to_encode = dict(a=1, b=obj)
+                encoded = json.dumps(to_encode)
+                decoded = json.loads(encoded)
+                assert to_encode == decoded
 
+    def test_complex(self):
+        naive_now = datetime.now()
+        aware_now = datetime.now(tzutc())
+        for now in [naive_now, aware_now]:
+            for obj in [now, now.date(), now.timetz(), now.time()]:
+                to_encode = dict(a=1, b=obj, c=dict(c1=2, c2=obj), d=[3, obj])
+                encoded = json.dumps(to_encode)
+                decoded = json.loads(encoded)
+                assert to_encode == decoded


### PR DESCRIPTION
Two improvements:
-support aware date time types, the previous one supports only naive datetime (no timezone support)
-keep time precision, the previous one supports the precision by 1 second
