### PR TITLE
Relative path for pidfile breaks on os.makedirs

### DIFF
--- a/pyres/__init__.py
+++ b/pyres/__init__.py
@@ -65,7 +65,7 @@ def setup_pidfile(path):
     if not path:
         return
     dirname = os.path.dirname(path)
-    if not os.path.exists(dirname):
+    if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
     with open(path, 'w') as f:
         f.write(str(os.getpid()))


### PR DESCRIPTION
In setup_pidfile, if path is relative to "." (i.e. -p my.pid) then os.path.dirname results in an empty string which os.makedirs will choke on.
