### PR TITLE
re-seed the Python random number generator after forking jobs

### DIFF
--- a/pyres/worker.py
+++ b/pyres/worker.py
@@ -4,6 +4,7 @@ import datetime, time
 import os, sys
 import json_parser as json
 import commands
+import random
 
 from pyres.exceptions import NoQueueError
 from pyres.job import Job
@@ -167,6 +168,12 @@ class Worker(object):
                     logger.info('Processing %s since %s' %
                                  (job._queue, datetime.datetime.now()))
                     self.after_fork(job)
+
+                    # re-seed the Python PRNG after forking, otherwise
+                    # all job process will share the same sequence of
+                    # random numbers
+                    random.seed()
+
                     self.process(job)
                     os._exit(0)
                 self.child = None


### PR DESCRIPTION
At some point during pyres_worker startup, the Python PRNG is
seeded. Since pyres_worker doesn't generate any random numbers on
its own, each job process that is forked starts with the PRNG in
the same state, and they share the same sequence of random numbers.

Fixes #82
https://github.com/binarydud/pyres/issues/82
