### PR TITLE
Updated pyres to work with pystache 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 simplejson==2.0.9
 itty==0.6.2
 redis>=1.34.1
-pystache==0.1.0
+pystache==0.5.0
 setproctitle>=1.0

--- a/resweb/views.py
+++ b/resweb/views.py
@@ -7,11 +7,15 @@ import os
 import datetime
 
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'templates')
-class ResWeb(pystache.View):
+class ResWeb(pystache.TemplateSpec):
     template_path = TEMPLATE_PATH
+    renderer = pystache.Renderer(search_dirs = template_path)
+
     def __init__(self, host):
-        super(ResWeb, self).__init__()
         self.resq = host
+
+    def render(self):
+        return self.renderer.render(self)
 
     def media_folder(self):
         return '/media/'
@@ -122,6 +126,7 @@ class Overview(ResWeb):
             return False
         else:
             return True
+
 class Queues(Overview):
     template_name = 'queue_full'
 


### PR DESCRIPTION
I noticed that pystache had changed a bit and you were no longer supposed to subclass View.  Since views.py uses template_name, I switched ResWeb to subclassing TemplateSpec.  I also added a bit of code to allow it to self render like before.  It might be a good idea to move that into server.py.
