### PR TITLE
before_perform() & after_perform() should be called on class, not pass i...

### DIFF
--- a/pyres/job.py
+++ b/pyres/job.py
@@ -78,7 +78,7 @@ class Job(object):
         check_after = True
         try:
             if before_perform:
-                before_perform(payload_class, metadata)
+                payload_class.before_perform(metadata)
             return payload_class.perform(*args)
         except:
             check_after = False
@@ -91,7 +91,7 @@ class Job(object):
         finally:
             after_perform = getattr(payload_class, "after_perform", None)
             if after_perform and check_after:
-                after_perform(payload_class, metadata)
+                payload_class.after_perform(metadata)
             delattr(payload_class,'resq')
 
     def fail(self, exception):


### PR DESCRIPTION
...t in

Fixes a problem where you would have:

```
@classmethod
def before_perform(cls, metadata):
    pass
```

and you would get an exception:

```
...
    before_perform(payload_class, metadata)
TypeError: before_perform() takes exactly 2 arguments (3 given)
```
