### PR TITLE
Add support for Redis db num in server string: i.e. localhost:6379/0

### DIFF
--- a/pyres/__init__.py
+++ b/pyres/__init__.py
@@ -113,7 +113,7 @@ class ResQ(object):
 
     The ``__init__`` takes these keyword arguments:
 
-        ``server`` -- IP address and port of the Redis server to which you want to connect. Default is `localhost:6379`.
+        ``server`` -- IP address and port of the Redis server to which you want to connect, and optional Redis DB number. Default is `localhost:6379`.
 
         ``password`` -- The password, if required, of your Redis server. Default is "None".
 
@@ -185,8 +185,9 @@ class ResQ(object):
     def _set_redis(self, server):
         if isinstance(server, basestring):
             self.dsn = server
-            host, port = server.split(':')
-            self._redis = Redis(host=host, port=int(port), password=self.password)
+            address, _, db = server.partition('/')
+            host, port = address.split(':')
+            self._redis = Redis(host=host, port=int(port), db=int(db or 0), password=self.password)
             self.host = host
             self.port = int(port)
         elif isinstance(server, Redis):

--- a/pyres/worker.py
+++ b/pyres/worker.py
@@ -19,7 +19,7 @@ class Worker(object):
     class and passes a comma-separated list of queues to listen on.::
 
        >>> from pyres.worker import Worker
-       >>> Worker.run([queue1, queue2], server="localhost:6379")
+       >>> Worker.run([queue1, queue2], server="localhost:6379/0")
 
     """
 


### PR DESCRIPTION
This pull request adds support to ResQ for an optional Redis db num.

Currently, ResQ omits the db num when instantiating the Redis client, so it always defaults to "0".  The code attached looks for an optional db num in the typical Redis "host:port/db" format.

nosetests pass, and documentation is updated to reflect the optional DB num, so AFAIK this is good to go.
