### PR TITLE
Add exception to metadata dictionary if job fails for use in after_perfo...

### DIFF
--- a/pyres/job.py
+++ b/pyres/job.py
@@ -81,9 +81,10 @@ class Job(object):
             if before_perform:
                 payload_class.before_perform(metadata)
             return payload_class.perform(*args)
-        except:
+        except Exception as e:
             check_after = False
             metadata["failed"] = True
+            metadata["exception"] = e
             if not self.retry(payload_class, args):
                 metadata["retried"] = False
                 raise


### PR DESCRIPTION
We log our exception data and this seemed like an elegant way to do so.  In our case, we wanted to log the exception only if it happened on the first try, so:

``` python
@staticmethod
def after_perform(metadata):
    if metadata['failed'] and not metadata['retried']:
        log_error(metadata['exception'])
```

Thanks for pyres!
