### PR TITLE
Registers worker again after a Redis flush

### DIFF
--- a/pyres/worker.py
+++ b/pyres/worker.py
@@ -51,9 +51,6 @@ class Worker(object):
         #self.resq._redis.add("worker:#{self}:started", Time.now.to_s)
         self.started = datetime.datetime.now()
 
-    def is_registered(self):
-        return self.resq.redis.sismember('resque:workers', str(self))
-
     def _set_started(self, dt):
         if dt:
             key = int(time.mktime(dt.timetuple()))
@@ -136,18 +133,12 @@ class Worker(object):
         logger.info("starting")
         self.startup()
 
-        check_worker_registration_wait = 3
-
         while True:
             if self._shutdown:
                 logger.info('shutdown scheduled')
                 break
 
-            check_worker_registration_wait -= 1
-            if not check_worker_registration_wait:
-                check_worker_registration_wait = 3
-                if not self.is_registered():
-                    self.register_worker()
+            self.register_worker()
 
             job = self.reserve(interval)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -39,11 +39,6 @@ class WorkerTests(PyResTests):
         worker.unregister_worker()
         assert name not in self.redis.smembers('resque:workers')
 
-    def test_worker_is_registered(self):
-        worker = Worker(['basic'])
-        worker.register_worker()
-        assert worker.is_registered()
-    
     def test_working_on(self):
         name = "%s:%s:%s" % (os.uname()[1],os.getpid(),'basic')
         self.resq.enqueue(Basic,"test1")


### PR DESCRIPTION
I was having problems after a flush on Redis.
The worker was still running but It wasn't on the workers list.
I thought it would be better to just register it again.
