### PR TITLE
Don't send extra data when getting the next delayed timestamp

### DIFF
--- a/pyres/__init__.py
+++ b/pyres/__init__.py
@@ -314,7 +314,7 @@ class ResQ(object):
     def next_delayed_timestamp(self):
         key = int(time.mktime(ResQ._current_time().timetuple()))
         array = self.redis.zrangebyscore('resque:delayed_queue_schedule',
-                                         '-inf', key)
+                                         '-inf', key, start=0, num=1)
         timestamp = None
         if array:
             timestamp = array[0]


### PR DESCRIPTION
I had a problem where the scheduler stopped for a while so the delayed jobs started backing up.   When the scheduler came back up each call to get_next_timestamp was returning the full set of timestamps, which became huge.  I was burning through the backlog at a rate of only a couple of jobs per second; after applying this patch that jumped to a couple hundred.
