### PR TITLE
same name of function and package, import job handler will encounter ImportError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.swp
 *.swo
 .tox/
+.idea/

--- a/pyres/__init__.py
+++ b/pyres/__init__.py
@@ -96,6 +96,19 @@ def safe_str_to_class(s):
     else:
         raise ImportError('')
 
+def safe_str_to_class_v2(s):
+    """Helper function to map string class names to module classes."""
+    lst = s.split(".")
+    klass = lst[-1]
+    mod_list = lst[:-1]
+    module = ".".join(mod_list)
+    import sys
+    mod = sys.modules.get(module)
+    if hasattr(mod, klass):
+        return getattr(mod, klass)
+    else:
+        raise ImportError('')
+
 def str_to_class(s):
     """Alternate helper function to map string class names to module classes."""
     lst = s.split(".")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -108,9 +108,13 @@ def test_str_to_class():
 class ImportTest(unittest.TestCase):
     def test_safe_str_to_class(self):
         from pyres import safe_str_to_class
+        from pyres import safe_str_to_class_v2
+        from tests.a import b
         assert safe_str_to_class('tests.Basic') == Basic
         self.assertRaises(ImportError, safe_str_to_class, 'test.Mine')
         self.assertRaises(ImportError, safe_str_to_class, 'tests.World')
+        self.assertRaises(ImportError, safe_str_to_class, '{}.{}'.format(b.__module__, b.__name__))
+        self.assertEqual(safe_str_to_class_v2('{}.{}'.format(b.__module__, b.__name__)), b)
 
 
 class PyResTests(unittest.TestCase):

--- a/tests/a/__init__.py
+++ b/tests/a/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, division
+from .a import a
+from .a import b

--- a/tests/a/a.py
+++ b/tests/a/a.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, division
+
+
+def a():
+    pass
+
+
+def b():
+    pass
+
+a.perform = lambda x: x
+b.perform = lambda x: x


### PR DESCRIPTION
`my_import` will walk job handler's module path from head to tail, but if a function exposed by a package, with  the same name of package, it will get the function instead of module.

this test makes a job handler called `b`, and its `__module__` is `tests.a.a`, also a function named `a` exposed by package `a`
