### PR TITLE
handle jobs queued by Ruby Resque with no module

### DIFF
--- a/pyres/__init__.py
+++ b/pyres/__init__.py
@@ -90,6 +90,15 @@ def safe_str_to_class(s):
     klass = lst[-1]
     mod_list = lst[:-1]
     module = ".".join(mod_list)
+
+    # ruby compatibility kludge: resque sends just a class name and
+    # not a module name so if I use resque to queue a ruby class
+    # called "Worker" then pyres will throw a "ValueError: Empty
+    # module name" exception.  To avoid that, if there's no module in
+    # the json then we'll use the classname as a module name.
+    if not module:
+        module = klass
+
     mod = my_import(module)
     if hasattr(mod, klass):
         return getattr(mod, klass)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,14 @@ import unittest
 import os
 from pyres import ResQ, str_to_class
 
+class tests(object):
+    queue = 'basic'
+
+    @staticmethod
+    def perform(name):
+        s = "name:%s" % name
+        return s
+
 class Basic(object):
     queue = 'basic'
 
@@ -111,7 +119,9 @@ class ImportTest(unittest.TestCase):
         assert safe_str_to_class('tests.Basic') == Basic
         self.assertRaises(ImportError, safe_str_to_class, 'test.Mine')
         self.assertRaises(ImportError, safe_str_to_class, 'tests.World')
-
+        # test that we'll use the class name as a module name if no
+        # module name is provided (for Ruby compatibility)
+        assert safe_str_to_class('tests') == tests
 
 class PyResTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Ruby compatibility: Resque sends just a class name and not a module name
so if I use Resque to queue a ruby class called "Worker" then Pyres will
throw a "ValueError: Empty module name" exception.  To avoid that, if
there's no module name in the json then we'll use the class name as a
module name.