### PR TITLE
a couple of Ruby-compatibility fixes

### DIFF
--- a/pyres/__init__.py
+++ b/pyres/__init__.py
@@ -86,7 +86,14 @@ def my_import(name):
 
 def safe_str_to_class(s):
     """Helper function to map string class names to module classes."""
-    lst = s.split(".")
+    # ruby compatibility kludge: ruby uses "::" to separate modules
+    # from classes, while python uses "." so we'll sniff the string
+    # for "::" and if it's there then we're probably handling a job
+    # that was queued by ruby
+    if "::" in s:
+        lst = s.split("::")
+    else:
+        lst = s.split(".")
     klass = lst[-1]
     mod_list = lst[:-1]
     module = ".".join(mod_list)

--- a/pyres/horde.py
+++ b/pyres/horde.py
@@ -109,7 +109,7 @@ class Minion(multiprocessing.Process):
         self.logger.debug('marking as working on')
         data = {
             'queue': job._queue,
-            'run_at': int(time.mktime(datetime.datetime.now().timetuple())),
+            'run_at': datetime.datetime.utcnow().isoformat() + "Z",
             'payload': job._payload
         }
         data = json.dumps(data)

--- a/pyres/worker.py
+++ b/pyres/worker.py
@@ -285,7 +285,7 @@ class Worker(object):
         logger.debug('marking as working on')
         data = {
             'queue': job._queue,
-            'run_at': str(int(time.mktime(datetime.datetime.now().timetuple()))),
+            'run_at': datetime.datetime.utcnow().isoformat() + "Z",
             'payload': job._payload
         }
         data = json.dumps(data)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -119,6 +119,8 @@ class ImportTest(unittest.TestCase):
         assert safe_str_to_class('tests.Basic') == Basic
         self.assertRaises(ImportError, safe_str_to_class, 'test.Mine')
         self.assertRaises(ImportError, safe_str_to_class, 'tests.World')
+        # test that we can handle Ruby-compatible Module::Class names
+        assert safe_str_to_class('tests::Basic') == Basic
         # test that we'll use the class name as a module name if no
         # module name is provided (for Ruby compatibility)
         assert safe_str_to_class('tests') == tests


### PR DESCRIPTION
Here are a couple of fixes that we've used to be able to use Ruby to queue jobs and Python to run them.  It's a great combo for us because the web guys like Ruby and the scientists like Python.

First fix: Ruby uses "::" to separate modules from classes, while python uses "."
so we'll sniff the queued class name for "::" and if it's there then
we're probably handling a job that was queued by Ruby.

Second fix: resque-web was crashing because pyres wrote the "run_at" field in a different format than resque.  This fix makes pyres use the same format as resque so now resque-web can show pyres jobs.

Thanks!