### PR TITLE
docs: fix simple typo, comming -> coming

### DIFF
--- a/docs/source/intentions.rst
+++ b/docs/source/intentions.rst
@@ -1,1 +1,1 @@
-comming soon
+coming soon


### PR DESCRIPTION
There is a small typo in docs/source/intentions.rst.

Should read `coming` rather than `comming`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md